### PR TITLE
feat(markdown-editor): add comprehensive markdown editor component with live preview and toolbar

### DIFF
--- a/docs/components/markdown_editor.md
+++ b/docs/components/markdown_editor.md
@@ -127,7 +127,7 @@ MarkdownEditor.simple(
 
 #### Constructors
 
-##### `MarkdownEditor.full()`
+##### `MarkdownEditor()`
 
 Full constructor with complete configuration options.
 
@@ -231,11 +231,11 @@ Implement `IMarkdownToolbarConfiguration` to customize toolbar behavior:
 ```dart
 class CustomToolbarConfiguration implements IMarkdownToolbarConfiguration {
   @override
-  Map<String, String> configureTooltipsUsingKeys() {
+  Map<String, String> configureTooltipsUsingKeys({Map<String, String>? translations}) {
     return {
-      'bold': 'Make text bold',
-      'italic': 'Make text italic',
-      // Custom tooltips
+      'bold': translations?['bold'] ?? 'Make text bold',
+      'italic': translations?['italic'] ?? 'Make text italic',
+      // Custom tooltips with optional localization
     };
   }
 

--- a/docs/components/markdown_editor.md
+++ b/docs/components/markdown_editor.md
@@ -1,0 +1,389 @@
+# Markdown Editor Component
+
+A comprehensive, reusable Markdown editor component built with Flutter.
+
+## Overview
+
+The Markdown editor provides a full-featured Markdown editing experience with:
+
+- Live editing with syntax highlighting (preview mode)
+- Configurable toolbar with common Markdown formatting tools
+- Link handling and URL launching
+- Responsive design for mobile and desktop
+- Clean, modular architecture for easy customization
+- Translation key support for internationalization
+
+## Features
+
+### Core Functionality
+
+- **Rich Text Editing**: Full Markdown support with live preview
+- **Toolbar Integration**: Common formatting tools (bold, italic, links, lists, etc.)
+- **Preview Mode**: Toggle between edit and preview modes
+- **Link Handling**: Automatic URL detection and launching
+- **Responsive Design**: Optimized for both mobile and desktop platforms
+
+### Customization Options
+
+- Configurable height and styling
+- Custom toolbar background colors
+- Optional preview mode toggle
+- Configurable tooltips using translation keys
+- Custom text styles and themes
+
+## Structure
+
+```
+markdown_editor/
+├── markdown_editor.dart           # Main orchestrator widget
+├── models/
+│   └── markdown_editor_interfaces.dart     # Abstract interfaces and data models
+├── controllers/
+│   └── markdown_editor_controller.dart     # Business logic and state management
+├── widgets/
+│   ├── markdown_editor_widget.dart         # Text input widget
+│   ├── markdown_preview_widget.dart        # Markdown preview widget
+│   └── markdown_toolbar_widget.dart        # Formatting toolbar widget
+├── services/
+│   ├── markdown_link_handler.dart          # URL and link handling
+│   └── markdown_style_provider.dart        # Styling and theming
+└── config/
+    ├── markdown_editor_translation_keys.dart  # Translation key constants
+    └── markdown_toolbar_configurator.dart   # Toolbar configuration
+```
+
+### Key Components
+
+#### Interfaces
+
+- **`IMarkdownToolbarConfiguration`**: Toolbar configuration interface
+- **`IMarkdownLinkHandler`**: Link handling and URL launching
+- **`IMarkdownStyleProvider`**: Styling and theme management
+
+#### Core Widgets
+
+- **`MarkdownEditor`**: Main editor widget with factory constructors
+- **`MarkdownEditorWidget`**: Text input component
+- **`MarkdownPreviewWidget`**: Markdown rendering component
+- **`MarkdownToolbarWidget`**: Formatting toolbar
+
+## Usage
+
+### Basic Usage
+
+```dart
+import 'package:acore/acore.dart' show MarkdownEditor;
+
+// Simple markdown editor with default configuration
+MarkdownEditor.simple(
+  controller: _textController,
+  onChanged: (text) {
+    // Handle text changes
+  },
+  height: 300,
+)
+```
+
+### Advanced Usage
+
+```dart
+import 'package:acore/acore.dart' show MarkdownEditor, MarkdownEditorConfig, MarkdownEditorCallbacks;
+
+// Fully configured markdown editor
+MarkdownEditor(
+  config: MarkdownEditorConfig(
+    height: 400,
+    showToolbar: true,
+    enablePreviewMode: true,
+    enableLinkHandling: true,
+    toolbarBackground: Colors.grey[100],
+  ),
+  callbacks: MarkdownEditorCallbacks(
+    onChanged: (text) => print('Text changed: $text'),
+    onTapLink: (text, href, title) => print('Link tapped: $href'),
+  ),
+  externalController: _textController,
+)
+```
+
+### Custom Styling
+
+```dart
+MarkdownEditor.simple(
+  controller: _textController,
+  onChanged: _onChanged,
+  height: 250,
+  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+    fontSize: 16,
+    height: 1.5,
+  ),
+  toolbarBackground: Theme.of(context).colorScheme.surface,
+)
+```
+
+## API Reference
+
+### MarkdownEditor
+
+#### Constructors
+
+##### `MarkdownEditor.full()`
+
+Full constructor with complete configuration options.
+
+```dart
+MarkdownEditor({
+  Key? key,
+  required MarkdownEditorConfig config,
+  required MarkdownEditorCallbacks callbacks,
+  TextEditingController? externalController,
+})
+```
+
+##### `MarkdownEditor.simple()`
+
+Convenience factory for common use cases.
+
+```dart
+MarkdownEditor.simple({
+  Key? key,
+  required TextEditingController controller,
+  void Function(String)? onChanged,
+  String? hintText,
+  TextStyle? style,
+  bool enableLinkHandling = true,
+  void Function(String text, String? href, String title)? onTapLink,
+  double? height,
+  Color? toolbarBackground,
+  bool enablePreviewMode = true,
+})
+```
+
+### MarkdownEditorConfig
+
+Configuration options for the editor behavior and appearance.
+
+```dart
+const MarkdownEditorConfig({
+  this.hintText,                    // Placeholder text
+  this.style,                       // Text styling
+  this.toolbarBackground,           // Toolbar background color
+  this.height,                      // Editor height
+  this.enableLinkHandling = true,   // Enable link click handling
+  this.showToolbar = true,          // Show formatting toolbar
+  this.enablePreviewMode = true,    // Enable preview mode toggle
+})
+```
+
+### MarkdownEditorCallbacks
+
+Event handlers for editor interactions.
+
+```dart
+const MarkdownEditorCallbacks({
+  this.onChanged,                   // Text change callback
+  this.onTapLink,                   // Link tap callback
+  this.onPreviewModeChanged,        // Preview mode change callback
+})
+```
+
+## Translation Support
+
+The component uses translation keys for internationalization:
+
+```dart
+import 'package:acore/components/markdown_editor/config/markdown_editor_translation_keys.dart';
+
+// Available translation keys:
+MarkdownEditorTranslationKeys.hintText
+MarkdownEditorTranslationKeys.editTooltip
+MarkdownEditorTranslationKeys.previewTooltip
+MarkdownEditorTranslationKeys.boldTooltip
+MarkdownEditorTranslationKeys.italicTooltip
+// ... and more
+```
+
+### Integration with App Localization
+
+Map the component's translation keys to your app's localization system:
+
+```dart
+// Example with easy_localization
+String translateMarkdownKey(String key) {
+  switch (key) {
+    case MarkdownEditorTranslationKeys.boldTooltip:
+      return 'bold'.tr();
+    case MarkdownEditorTranslationKeys.italicTooltip:
+      return 'italic'.tr();
+    // ... other mappings
+    default:
+      return key;
+  }
+}
+```
+
+## Customization
+
+### Custom Toolbar Configuration
+
+Implement `IMarkdownToolbarConfiguration` to customize toolbar behavior:
+
+```dart
+class CustomToolbarConfiguration implements IMarkdownToolbarConfiguration {
+  @override
+  Map<String, String> configureTooltipsUsingKeys() {
+    return {
+      'bold': 'Make text bold',
+      'italic': 'Make text italic',
+      // Custom tooltips
+    };
+  }
+
+  @override
+  MarkdownToolbarStyle configureToolbarStyle(ThemeData theme, Color? backgroundColor) {
+    return MarkdownToolbarStyle(
+      iconColor: theme.primaryColor,
+      iconSize: 24.0,
+      // Custom styling
+    );
+  }
+}
+```
+
+### Custom Link Handling
+
+Implement `IMarkdownLinkHandler` for custom link behavior:
+
+```dart
+class CustomLinkHandler implements IMarkdownLinkHandler {
+  @override
+  void handleLinkTap(String text, String? href, String title) {
+    // Custom link handling logic
+    if (href?.startsWith('internal://') == true) {
+      // Handle internal navigation
+    } else {
+      launchUrl(href!);
+    }
+  }
+}
+```
+
+## Styling
+
+### Default Styling
+
+The component automatically adapts to your app's theme:
+
+- Uses `Theme.of(context)` for colors and typography
+- Supports both light and dark themes
+- Responsive design for different screen sizes
+
+### Custom Styling Examples
+
+```dart
+// Custom editor styling
+MarkdownEditor.simple(
+  controller: _controller,
+  style: TextStyle(
+    fontFamily: 'Courier New',
+    fontSize: 14,
+    height: 1.6,
+    color: Colors.black87,
+  ),
+  toolbarBackground: Colors.blueGrey[50],
+  height: 300,
+)
+```
+
+## Performance Considerations
+
+- **Lazy Loading**: Preview mode renders on-demand
+- **Efficient Updates**: Only re-renders when text actually changes
+- **Memory Management**: Proper disposal of controllers and resources
+- **Responsive Design**: Optimized layouts for different screen sizes
+
+## Platform Support
+
+- **Mobile**: Android and iOS with touch-friendly interface
+- **Desktop**: Web, Windows, Linux, macOS with keyboard shortcuts
+- **Responsive**: Automatic adaptation to screen size
+
+## Dependencies
+
+The component requires these Flutter packages:
+
+- `flutter_markdown`: ^0.7.6+3
+- `markdown_toolbar`: ^0.5.0
+- `url_launcher`: ^6.3.0+3
+
+## Examples
+
+### Note Taking App
+
+```dart
+class NoteEditor extends StatefulWidget {
+  @override
+  _NoteEditorState createState() => _NoteEditorState();
+}
+
+class _NoteEditorState extends State<NoteEditor> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Note Editor')),
+      body: Padding(
+        padding: EdgeInsets.all(16.0),
+        child: MarkdownEditor.simple(
+          controller: _controller,
+          height: MediaQuery.of(context).size.height - 200,
+          onChanged: (text) => _saveNote(text),
+        ),
+      ),
+    );
+  }
+}
+```
+
+### Blog Post Editor
+
+```dart
+MarkdownEditor(
+  config: MarkdownEditorConfig(
+    height: 600,
+    showToolbar: true,
+    enablePreviewMode: true,
+    enableLinkHandling: true,
+  ),
+  callbacks: MarkdownEditorCallbacks(
+    onChanged: (text) => _autoSave(text),
+    onTapLink: (text, href, title) => _handleLink(href),
+  ),
+  externalController: _postController,
+)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Toolbar not showing**: Ensure `showToolbar: true` in config
+2. **Links not working**: Check `enableLinkHandling` configuration
+3. **Preview mode not available**: Ensure `enablePreviewMode: true`
+4. **Height issues**: Set explicit height or use parent container constraints
+
+### Performance Tips
+
+- Use external controllers for better state management
+- Dispose controllers properly when not needed
+- Consider debouncing `onChanged` callbacks for large texts
+
+## Contributing
+
+When extending the component:
+
+1. Maintain interface contracts
+2. Add appropriate tests
+3. Update documentation
+4. Consider backward compatibility

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -12,5 +12,6 @@ export 'date_time_picker/footer_action_base.dart';
 export 'date_time_picker/quick_range_selector.dart';
 export 'date_time_picker/time_selector.dart';
 export 'date_time_picker/time_selection_dialog.dart';
+export 'markdown_editor/markdown_editor.dart';
 export 'numeric_input/numeric_input.dart';
 export 'numeric_input/numeric_input_translation_keys.dart';

--- a/lib/components/markdown_editor/config/markdown_editor_translation_keys.dart
+++ b/lib/components/markdown_editor/config/markdown_editor_translation_keys.dart
@@ -1,0 +1,17 @@
+class MarkdownEditorTranslationKeys {
+  static const String hintText = 'markdown_editor.hint_text';
+  static const String editTooltip = 'markdown_editor.edit_tooltip';
+  static const String previewTooltip = 'markdown_editor.preview_tooltip';
+  static const String imageTooltip = 'markdown_editor.image_tooltip';
+  static const String headingTooltip = 'markdown_editor.heading_tooltip';
+  static const String checkboxTooltip = 'markdown_editor.checkbox_tooltip';
+  static const String boldTooltip = 'markdown_editor.bold_tooltip';
+  static const String italicTooltip = 'markdown_editor.italic_tooltip';
+  static const String strikethroughTooltip = 'markdown_editor.strikethrough_tooltip';
+  static const String linkTooltip = 'markdown_editor.link_tooltip';
+  static const String codeTooltip = 'markdown_editor.code_tooltip';
+  static const String bulletedListTooltip = 'markdown_editor.bulleted_list_tooltip';
+  static const String numberedListTooltip = 'markdown_editor.numbered_list_tooltip';
+  static const String quoteTooltip = 'markdown_editor.quote_tooltip';
+  static const String horizontalRuleTooltip = 'markdown_editor.horizontal_rule_tooltip';
+}

--- a/lib/components/markdown_editor/config/markdown_toolbar_configuration.dart
+++ b/lib/components/markdown_editor/config/markdown_toolbar_configuration.dart
@@ -24,15 +24,21 @@ class MarkdownToolbarConfiguration implements IMarkdownToolbarConfiguration {
 
   @override
   MarkdownToolbarStyle configureToolbarStyle(ThemeData theme, Color? backgroundColor) {
+    // Calculate theme-aware dimensions
+    final baseIconSize = theme.iconTheme.size ?? 20.0;
+    final scaleFactor = baseIconSize / 20.0; // Scale based on standard 20px
+    final scaledPadding = 16.0 * scaleFactor;
+    final scaledSpacing = 4.0 * scaleFactor;
+
     return MarkdownToolbarStyle(
       iconColor: theme.colorScheme.primary,
       dropdownTextColor: theme.colorScheme.primary,
-      iconSize: 20.0,
-      width: 36.0,
-      height: 36.0,
-      spacing: 4.0,
-      runSpacing: 4.0,
-      borderRadius: BorderRadius.circular(8),
+      iconSize: baseIconSize,
+      width: baseIconSize + scaledPadding,
+      height: baseIconSize + scaledPadding,
+      spacing: scaledSpacing,
+      runSpacing: scaledSpacing,
+      borderRadius: BorderRadius.circular(8 * scaleFactor),
       collapsible: false,
     );
   }

--- a/lib/components/markdown_editor/config/markdown_toolbar_configuration.dart
+++ b/lib/components/markdown_editor/config/markdown_toolbar_configuration.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import '../models/markdown_editor_interfaces.dart';
+import 'markdown_editor_translation_keys.dart';
+
+/// Default implementation of markdown toolbar configuration
+class MarkdownToolbarConfiguration implements IMarkdownToolbarConfiguration {
+  @override
+  Map<String, String> configureTooltipsUsingKeys({Map<String, String>? translations}) {
+    return {
+      'image': translations?[MarkdownEditorTranslationKeys.imageTooltip] ?? 'Image',
+      'heading': translations?[MarkdownEditorTranslationKeys.headingTooltip] ?? 'Heading',
+      'checkbox': translations?[MarkdownEditorTranslationKeys.checkboxTooltip] ?? 'Checkbox',
+      'bold': translations?[MarkdownEditorTranslationKeys.boldTooltip] ?? 'Bold',
+      'italic': translations?[MarkdownEditorTranslationKeys.italicTooltip] ?? 'Italic',
+      'strikethrough': translations?[MarkdownEditorTranslationKeys.strikethroughTooltip] ?? 'Strikethrough',
+      'link': translations?[MarkdownEditorTranslationKeys.linkTooltip] ?? 'Link',
+      'code': translations?[MarkdownEditorTranslationKeys.codeTooltip] ?? 'Code',
+      'bulletedList': translations?[MarkdownEditorTranslationKeys.bulletedListTooltip] ?? 'Bulleted List',
+      'numberedList': translations?[MarkdownEditorTranslationKeys.numberedListTooltip] ?? 'Numbered List',
+      'quote': translations?[MarkdownEditorTranslationKeys.quoteTooltip] ?? 'Quote',
+      'horizontalRule': translations?[MarkdownEditorTranslationKeys.horizontalRuleTooltip] ?? 'Horizontal Rule',
+    };
+  }
+
+  @override
+  MarkdownToolbarStyle configureToolbarStyle(ThemeData theme, Color? backgroundColor) {
+    return MarkdownToolbarStyle(
+      iconColor: theme.colorScheme.primary,
+      dropdownTextColor: theme.colorScheme.primary,
+      iconSize: 20.0,
+      width: 36.0,
+      height: 36.0,
+      spacing: 4.0,
+      runSpacing: 4.0,
+      borderRadius: BorderRadius.circular(8),
+      collapsible: false,
+    );
+  }
+}

--- a/lib/components/markdown_editor/controllers/markdown_editor_controller.dart
+++ b/lib/components/markdown_editor/controllers/markdown_editor_controller.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import '../models/markdown_editor_interfaces.dart';
+
+/// Controls the markdown editor's state and operations
+class MarkdownEditorController {
+  final TextEditingController textController;
+  final FocusNode focusNode;
+  final MarkdownEditorConfig config;
+  final MarkdownEditorCallbacks callbacks;
+  final IMarkdownLinkHandler linkHandler;
+  final IMarkdownStyleProvider styleProvider;
+  final IMarkdownToolbarConfiguration toolbarConfiguration;
+
+  final MarkdownEditorState _state = MarkdownEditorState();
+  VoidCallback? _onStateChanged;
+
+  MarkdownEditorController({
+    required this.textController,
+    required this.config,
+    required this.callbacks,
+    required this.linkHandler,
+    required this.styleProvider,
+    required this.toolbarConfiguration,
+    VoidCallback? onStateChanged,
+  }) : focusNode = FocusNode() {
+    _onStateChanged = onStateChanged;
+    _initialize();
+  }
+
+  MarkdownEditorState get state => _state;
+
+  bool get isPreviewMode => _state.isPreviewMode;
+  bool get isInitializing => _state.isInitializing;
+
+  void _initialize() {
+    _state.setPreviewMode(false);
+
+    _state.onStateChanged = () {
+      callbacks.onPreviewModeChanged?.call(_state.isPreviewMode);
+      _onStateChanged?.call();
+    };
+
+    _addTextChangeListener();
+  }
+
+  void _addTextChangeListener() {
+    textController.addListener(_onTextChanged);
+  }
+
+  void _removeTextChangeListener() {
+    try {
+      textController.removeListener(_onTextChanged);
+    } catch (e) {}
+  }
+
+  void _onTextChanged() {
+    if (_state.isInitializing) return;
+
+    try {
+      callbacks.onChanged?.call(textController.text);
+    } catch (e) {}
+  }
+
+  void togglePreviewMode() {
+    if (!_state.isPreviewMode) {
+      _state.setPreviewMode(true);
+    } else {
+      _state.setPreviewMode(false);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (focusNode.canRequestFocus) {
+          focusNode.requestFocus();
+        }
+      });
+    }
+  }
+
+  void setInitializing(bool isInitializing) {
+    _state.setInitializing(isInitializing);
+  }
+
+  /// Request focus for the text editor
+  void requestFocus() {
+    if (focusNode.canRequestFocus && !focusNode.hasFocus) {
+      focusNode.requestFocus();
+    }
+  }
+
+  /// Handle link tap in preview mode
+  void handleLinkTap(String text, String? href, String title) {
+    if (config.enableLinkHandling) {
+      if (callbacks.onTapLink != null) {
+        callbacks.onTapLink!(text, href, title);
+      } else {
+        linkHandler.handleLinkTap(text, href, title);
+      }
+    }
+  }
+
+  /// Dispose resources
+  void dispose() {
+    _removeTextChangeListener();
+    focusNode.dispose();
+  }
+}

--- a/lib/components/markdown_editor/controllers/markdown_editor_controller.dart
+++ b/lib/components/markdown_editor/controllers/markdown_editor_controller.dart
@@ -50,7 +50,10 @@ class MarkdownEditorController {
   void _removeTextChangeListener() {
     try {
       textController.removeListener(_onTextChanged);
-    } catch (e) {}
+    } catch (e) {
+      // Log errors for debugging - removeListener should not typically throw
+      debugPrint('Error removing text change listener: $e');
+    }
   }
 
   void _onTextChanged() {
@@ -58,7 +61,11 @@ class MarkdownEditorController {
 
     try {
       callbacks.onChanged?.call(textController.text);
-    } catch (e) {}
+    } catch (e) {
+      // Propagate user callback errors for better debugging
+      debugPrint('Error in onChanged callback: $e');
+      rethrow;
+    }
   }
 
   void togglePreviewMode() {

--- a/lib/components/markdown_editor/index.dart
+++ b/lib/components/markdown_editor/index.dart
@@ -1,0 +1,1 @@
+export 'markdown_editor.dart';

--- a/lib/components/markdown_editor/markdown_editor.dart
+++ b/lib/components/markdown_editor/markdown_editor.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+import 'models/markdown_editor_interfaces.dart';
+import 'controllers/markdown_editor_controller.dart';
+import 'widgets/markdown_editor_widget.dart';
+import 'widgets/markdown_preview_widget.dart';
+import 'widgets/markdown_toolbar_widget.dart';
+import 'config/markdown_toolbar_configuration.dart';
+import 'services/markdown_link_handler.dart';
+import 'services/markdown_style_provider.dart';
+import 'config/markdown_editor_translation_keys.dart';
+
+/// A reusable Markdown editor component
+/// with clean separation of concerns and modular architecture.
+/// This version is designed for the acore package and requires all dependencies
+/// to be injected via constructor parameters.
+class MarkdownEditor extends StatefulWidget {
+  final MarkdownEditorConfig config;
+  final MarkdownEditorCallbacks callbacks;
+  final TextEditingController? externalController;
+
+  const MarkdownEditor({
+    super.key,
+    required this.config,
+    required this.callbacks,
+    this.externalController,
+  });
+  factory MarkdownEditor.simple({
+    Key? key,
+    required TextEditingController controller,
+    void Function(String)? onChanged,
+    String? hintText,
+    TextStyle? style,
+    bool enableLinkHandling = true,
+    void Function(String text, String? href, String title)? onTapLink,
+    double? height,
+    Color? toolbarBackground,
+    bool enablePreviewMode = true,
+    Map<String, String>? translations,
+  }) {
+    return MarkdownEditor(
+      key: key,
+      externalController: controller,
+      config: MarkdownEditorConfig(
+        hintText: hintText ?? MarkdownEditorTranslationKeys.hintText,
+        style: style,
+        toolbarBackground: toolbarBackground,
+        height: height,
+        enableLinkHandling: enableLinkHandling,
+        enablePreviewMode: enablePreviewMode,
+        translations: translations,
+      ),
+      callbacks: MarkdownEditorCallbacks(
+        onChanged: onChanged,
+        onTapLink: onTapLink,
+      ),
+    );
+  }
+
+  @override
+  State<MarkdownEditor> createState() => _MarkdownEditorState();
+}
+
+class _MarkdownEditorState extends State<MarkdownEditor> {
+  late final MarkdownEditorController _editorController;
+  late final IMarkdownToolbarConfiguration _toolbarConfigurator;
+  late final IMarkdownLinkHandler _linkHandler;
+  late final IMarkdownStyleProvider _styleProvider;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeDependencies();
+    _createEditorController();
+    _setupInitialization();
+  }
+
+  void _initializeDependencies() {
+    _toolbarConfigurator = MarkdownToolbarConfiguration();
+    _linkHandler = MarkdownLinkHandler();
+    _styleProvider = MarkdownStyleProvider();
+  }
+
+  void _createEditorController() {
+    final controller = widget.externalController ?? TextEditingController();
+
+    _editorController = MarkdownEditorController(
+      textController: controller,
+      config: widget.config,
+      callbacks: widget.callbacks,
+      linkHandler: _linkHandler,
+      styleProvider: _styleProvider,
+      toolbarConfiguration: _toolbarConfigurator,
+      onStateChanged: () {
+        if (mounted) {
+          setState(() {});
+        }
+      },
+    );
+  }
+
+  void _setupInitialization() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        try {
+          _editorController.setInitializing(false);
+        } catch (e) {
+          _editorController.setInitializing(false);
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _editorController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: widget.config.height ?? 400,
+      ),
+      child: Column(
+        children: [
+          if (widget.config.showToolbar && !_editorController.isPreviewMode)
+            MarkdownToolbarWidget(
+              controller: _editorController.textController,
+              focusNode: _editorController.focusNode,
+              backgroundColor: widget.config.toolbarBackground,
+              showPreviewToggle: widget.config.enablePreviewMode,
+              isPreviewMode: _editorController.isPreviewMode,
+              onPreviewToggle: widget.config.enablePreviewMode ? _editorController.togglePreviewMode : null,
+              toolbarConfiguration: _toolbarConfigurator,
+              translations: widget.config.translations,
+            ),
+
+          // Editor/Preview Section
+          Expanded(
+            child: Container(
+              decoration: const BoxDecoration(
+                color: Colors.transparent,
+              ),
+              child: Stack(
+                children: [
+                  if (_editorController.isPreviewMode) _buildPreviewContent() else _buildEditorContent(),
+                  if (widget.config.enablePreviewMode && _editorController.isPreviewMode)
+                    _buildFloatingEditButton(theme),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEditorContent() {
+    return MarkdownEditorWidget(
+      controller: _editorController.textController,
+      focusNode: _editorController.focusNode,
+      hintText: widget.config.hintText,
+      style: widget.config.style,
+      onTap: _editorController.requestFocus,
+    );
+  }
+
+  Widget _buildPreviewContent() {
+    return MarkdownPreviewWidget(
+      controller: _editorController.textController,
+      hintText: widget.config.hintText,
+      enableLinkHandling: widget.config.enableLinkHandling,
+      onTapLink: _editorController.handleLinkTap,
+      styleProvider: _styleProvider,
+    );
+  }
+
+  Widget _buildFloatingEditButton(ThemeData theme) {
+    return Positioned(
+      top: 8,
+      right: 8,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: IconButton(
+          icon: Icon(
+            Icons.edit,
+            size: 20,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+          ),
+          onPressed: _editorController.togglePreviewMode,
+          tooltip: widget.config.translations?[MarkdownEditorTranslationKeys.editTooltip] ?? 'Edit',
+          padding: const EdgeInsets.all(4),
+          constraints: const BoxConstraints(
+            minWidth: 32,
+            minHeight: 32,
+          ),
+          style: IconButton.styleFrom(
+            backgroundColor: Colors.transparent,
+            foregroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+            hoverColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/markdown_editor/markdown_editor.dart
+++ b/lib/components/markdown_editor/markdown_editor.dart
@@ -66,6 +66,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
   late final IMarkdownToolbarConfiguration _toolbarConfigurator;
   late final IMarkdownLinkHandler _linkHandler;
   late final IMarkdownStyleProvider _styleProvider;
+  late final bool _internalControllerCreated;
 
   @override
   void initState() {
@@ -83,6 +84,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
 
   void _createEditorController() {
     final controller = widget.externalController ?? TextEditingController();
+    _internalControllerCreated = widget.externalController == null;
 
     _editorController = MarkdownEditorController(
       textController: controller,
@@ -102,17 +104,17 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
   void _setupInitialization() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        try {
-          _editorController.setInitializing(false);
-        } catch (e) {
-          _editorController.setInitializing(false);
-        }
+        _editorController.setInitializing(false);
       }
     });
   }
 
   @override
   void dispose() {
+    // Dispose the TextEditingController if it was created internally
+    if (_internalControllerCreated) {
+      _editorController.textController.dispose();
+    }
     _editorController.dispose();
     super.dispose();
   }

--- a/lib/components/markdown_editor/markdown_editor.dart
+++ b/lib/components/markdown_editor/markdown_editor.dart
@@ -66,7 +66,6 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
   late final IMarkdownToolbarConfiguration _toolbarConfigurator;
   late final IMarkdownLinkHandler _linkHandler;
   late final IMarkdownStyleProvider _styleProvider;
-  late final bool _internalControllerCreated;
 
   @override
   void initState() {
@@ -84,7 +83,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
 
   void _createEditorController() {
     final controller = widget.externalController ?? TextEditingController();
-    _internalControllerCreated = widget.externalController == null;
+    final ownsController = widget.externalController == null;
 
     _editorController = MarkdownEditorController(
       textController: controller,
@@ -93,6 +92,7 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
       linkHandler: _linkHandler,
       styleProvider: _styleProvider,
       toolbarConfiguration: _toolbarConfigurator,
+      ownsController: ownsController,
       onStateChanged: () {
         if (mounted) {
           setState(() {});
@@ -111,10 +111,6 @@ class _MarkdownEditorState extends State<MarkdownEditor> {
 
   @override
   void dispose() {
-    // Dispose the TextEditingController if it was created internally
-    if (_internalControllerCreated) {
-      _editorController.textController.dispose();
-    }
     _editorController.dispose();
     super.dispose();
   }

--- a/lib/components/markdown_editor/models/markdown_editor_interfaces.dart
+++ b/lib/components/markdown_editor/models/markdown_editor_interfaces.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
@@ -10,6 +11,7 @@ class MarkdownEditorConfig {
   final bool showToolbar;
   final bool enablePreviewMode;
   final Map<String, String>? translations;
+  final Duration textChangeDebounce;
 
   const MarkdownEditorConfig({
     this.hintText,
@@ -20,6 +22,7 @@ class MarkdownEditorConfig {
     this.showToolbar = true,
     this.enablePreviewMode = true,
     this.translations,
+    this.textChangeDebounce = const Duration(milliseconds: 300),
   });
 
   MarkdownEditorConfig copyWith({
@@ -31,6 +34,7 @@ class MarkdownEditorConfig {
     bool? showToolbar,
     bool? enablePreviewMode,
     Map<String, String>? translations,
+    Duration? textChangeDebounce,
   }) {
     return MarkdownEditorConfig(
       hintText: hintText ?? this.hintText,
@@ -41,6 +45,7 @@ class MarkdownEditorConfig {
       showToolbar: showToolbar ?? this.showToolbar,
       enablePreviewMode: enablePreviewMode ?? this.enablePreviewMode,
       translations: translations ?? this.translations,
+      textChangeDebounce: textChangeDebounce ?? this.textChangeDebounce,
     );
   }
 }

--- a/lib/components/markdown_editor/models/markdown_editor_interfaces.dart
+++ b/lib/components/markdown_editor/models/markdown_editor_interfaces.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+
+class MarkdownEditorConfig {
+  final String? hintText;
+  final TextStyle? style;
+  final Color? toolbarBackground;
+  final double? height;
+  final bool enableLinkHandling;
+  final bool showToolbar;
+  final bool enablePreviewMode;
+  final Map<String, String>? translations;
+
+  const MarkdownEditorConfig({
+    this.hintText,
+    this.style,
+    this.toolbarBackground,
+    this.height,
+    this.enableLinkHandling = true,
+    this.showToolbar = true,
+    this.enablePreviewMode = true,
+    this.translations,
+  });
+
+  MarkdownEditorConfig copyWith({
+    String? hintText,
+    TextStyle? style,
+    Color? toolbarBackground,
+    double? height,
+    bool? enableLinkHandling,
+    bool? showToolbar,
+    bool? enablePreviewMode,
+    Map<String, String>? translations,
+  }) {
+    return MarkdownEditorConfig(
+      hintText: hintText ?? this.hintText,
+      style: style ?? this.style,
+      toolbarBackground: toolbarBackground ?? this.toolbarBackground,
+      height: height ?? this.height,
+      enableLinkHandling: enableLinkHandling ?? this.enableLinkHandling,
+      showToolbar: showToolbar ?? this.showToolbar,
+      enablePreviewMode: enablePreviewMode ?? this.enablePreviewMode,
+      translations: translations ?? this.translations,
+    );
+  }
+}
+
+class MarkdownEditorCallbacks {
+  final void Function(String)? onChanged;
+  final void Function(String text, String? href, String title)? onTapLink;
+  final void Function(bool)? onPreviewModeChanged;
+
+  const MarkdownEditorCallbacks({
+    this.onChanged,
+    this.onTapLink,
+    this.onPreviewModeChanged,
+  });
+}
+
+abstract class IMarkdownLinkHandler {
+  void handleLinkTap(String text, String? href, String title);
+  Future<void> launchUrl(String url);
+}
+
+abstract class IMarkdownStyleProvider {
+  MarkdownStyleSheet createStyleSheet(BuildContext context);
+  MarkdownStyleSheet createHintStyleSheet(BuildContext context);
+  TextStyle getEditorStyle(BuildContext context, TextStyle? customStyle);
+  TextStyle getHintStyle(BuildContext context);
+}
+
+abstract class IMarkdownToolbarConfiguration {
+  Map<String, String> configureTooltipsUsingKeys({Map<String, String>? translations});
+  MarkdownToolbarStyle configureToolbarStyle(ThemeData theme, Color? backgroundColor);
+}
+
+class MarkdownToolbarStyle {
+  final Color iconColor;
+  final Color dropdownTextColor;
+  final double iconSize;
+  final double width;
+  final double height;
+  final double spacing;
+  final double runSpacing;
+  final BorderRadius borderRadius;
+  final bool collapsible;
+  final WrapAlignment? alignment;
+
+  const MarkdownToolbarStyle({
+    this.iconColor = Colors.blue,
+    this.dropdownTextColor = Colors.blue,
+    this.iconSize = 20.0,
+    this.width = 36.0,
+    this.height = 36.0,
+    this.spacing = 4.0,
+    this.runSpacing = 4.0,
+    this.borderRadius = const BorderRadius.all(Radius.circular(8)),
+    this.collapsible = false,
+    this.alignment,
+  });
+}
+
+class MarkdownEditorState {
+  bool _isPreviewMode = false;
+  bool _isInitializing = true;
+  VoidCallback? onStateChanged;
+
+  MarkdownEditorState({this.onStateChanged});
+
+  bool get isPreviewMode => _isPreviewMode;
+  bool get isInitializing => _isInitializing;
+
+  void setPreviewMode(bool isPreview) {
+    if (_isPreviewMode != isPreview) {
+      _isPreviewMode = isPreview;
+      onStateChanged?.call();
+    }
+  }
+
+  void setInitializing(bool isInitializing) {
+    if (_isInitializing != isInitializing) {
+      _isInitializing = isInitializing;
+      onStateChanged?.call();
+    }
+  }
+
+  void togglePreviewMode() {
+    setPreviewMode(!_isPreviewMode);
+  }
+}

--- a/lib/components/markdown_editor/services/markdown_link_handler.dart
+++ b/lib/components/markdown_editor/services/markdown_link_handler.dart
@@ -1,0 +1,29 @@
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
+import 'dart:developer' as developer;
+import '../models/markdown_editor_interfaces.dart';
+
+/// Default implementation of markdown link handling
+class MarkdownLinkHandler implements IMarkdownLinkHandler {
+  @override
+  void handleLinkTap(String text, String? href, String title) {
+    if (href != null && href.isNotEmpty) {
+      launchUrl(href);
+    }
+  }
+
+  @override
+  Future<void> launchUrl(String url) async {
+    try {
+      if (url.isEmpty) return;
+
+      final uri = Uri.parse(url);
+      if (await url_launcher.canLaunchUrl(uri)) {
+        await url_launcher.launchUrl(uri);
+      } else {
+        developer.log('Could not launch $url');
+      }
+    } catch (e) {
+      developer.log('Error launching URL $url: $e');
+    }
+  }
+}

--- a/lib/components/markdown_editor/services/markdown_link_handler.dart
+++ b/lib/components/markdown_editor/services/markdown_link_handler.dart
@@ -1,9 +1,28 @@
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'dart:developer' as developer;
+import 'package:flutter/foundation.dart';
 import '../models/markdown_editor_interfaces.dart';
 
-/// Default implementation of markdown link handling
+/// Default implementation of markdown link handling with security validation
 class MarkdownLinkHandler implements IMarkdownLinkHandler {
+  // List of allowed URL schemes for security
+  static const List<String> _allowedSchemes = [
+    'http',
+    'https',
+    'mailto',
+    'tel',
+    'sms',
+  ];
+
+  // List of potentially dangerous schemes to block
+  static const List<String> _blockedSchemes = [
+    'javascript',
+    'data',
+    'vbscript',
+    'file',
+    'ftp',
+  ];
+
   @override
   void handleLinkTap(String text, String? href, String title) {
     if (href != null && href.isNotEmpty) {
@@ -14,16 +33,104 @@ class MarkdownLinkHandler implements IMarkdownLinkHandler {
   @override
   Future<void> launchUrl(String url) async {
     try {
-      if (url.isEmpty) return;
+      if (url.isEmpty) {
+        developer.log('Empty URL provided');
+        return;
+      }
 
-      final uri = Uri.parse(url);
-      if (await url_launcher.canLaunchUrl(uri)) {
-        await url_launcher.launchUrl(uri);
-      } else {
-        developer.log('Could not launch $url');
+      final uri = Uri.tryParse(url);
+      if (uri == null) {
+        developer.log('Invalid URL format: $url');
+        return;
+      }
+
+      // Security validation
+      if (!_isUrlSafe(uri)) {
+        developer.log('Blocked potentially unsafe URL: $url');
+        return;
+      }
+
+      // Additional validation for external URLs
+      if (_isExternalUrl(uri)) {
+        if (!await _validateExternalUrl(uri)) {
+          developer.log('Could not validate external URL: $url');
+          return;
+        }
+      }
+
+      final launched = await url_launcher.launchUrl(
+        uri,
+        mode: url_launcher.LaunchMode.externalApplication,
+      );
+
+      if (!launched) {
+        developer.log('Could not launch URL: $url');
       }
     } catch (e) {
       developer.log('Error launching URL $url: $e');
+      if (!kReleaseMode) {
+        debugPrint('URL Launch Error: $e');
+      }
     }
   }
+
+  /// Validates if a URL is safe to launch
+  bool _isUrlSafe(Uri uri) {
+    // Check for blocked schemes
+    if (_blockedSchemes.contains(uri.scheme.toLowerCase())) {
+      return false;
+    }
+
+    // Check if scheme is in allowed list
+    if (uri.scheme.isEmpty) {
+      return false; // No scheme specified
+    }
+
+    if (!_allowedSchemes.contains(uri.scheme.toLowerCase())) {
+      developer.log('URL scheme not in allowed list: ${uri.scheme}');
+      return false;
+    }
+
+    // Additional checks for HTTP/HTTPS URLs
+    if (uri.scheme.toLowerCase() == 'http' || uri.scheme.toLowerCase() == 'https') {
+      // Block localhost in release mode
+      if (kReleaseMode && _isLocalhostUrl(uri)) {
+        developer.log('Localhost URL blocked in release mode: $uri');
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Checks if URL is external (not relative)
+  bool _isExternalUrl(Uri uri) {
+    return uri.scheme.isNotEmpty;
+  }
+
+  /// Validates external URLs can be launched
+  Future<bool> _validateExternalUrl(Uri uri) async {
+    try {
+      return await url_launcher.canLaunchUrl(uri);
+    } catch (e) {
+      developer.log('Error validating URL $uri: $e');
+      return false;
+    }
+  }
+
+  /// Checks if URL points to localhost
+  bool _isLocalhostUrl(Uri uri) {
+    final host = uri.host.toLowerCase();
+    return host == 'localhost' ||
+        host == '127.0.0.1' ||
+        host.startsWith('192.168.') ||
+        host.startsWith('10.') ||
+        host.endsWith('.local');
+  }
+
+  /// Gets allowed schemes for testing/configuration
+  static List<String> get allowedSchemes => List.unmodifiable(_allowedSchemes);
+
+  /// Gets blocked schemes for testing/configuration
+  static List<String> get blockedSchemes => List.unmodifiable(_blockedSchemes);
 }

--- a/lib/components/markdown_editor/services/markdown_style_provider.dart
+++ b/lib/components/markdown_editor/services/markdown_style_provider.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import '../models/markdown_editor_interfaces.dart';
+
+/// Default implementation of markdown styling configuration
+class MarkdownStyleProvider implements IMarkdownStyleProvider {
+  @override
+  MarkdownStyleSheet createStyleSheet(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return MarkdownStyleSheet(
+      p: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface,
+        height: 1.5,
+      ),
+      h1: theme.textTheme.displayLarge?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 32.0,
+      ),
+      h2: theme.textTheme.headlineLarge?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 28.0,
+      ),
+      h3: theme.textTheme.headlineMedium?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 24.0,
+      ),
+      h4: theme.textTheme.headlineSmall?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 20.0,
+      ),
+      h5: theme.textTheme.headlineSmall?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 16.0,
+      ),
+      h6: theme.textTheme.headlineSmall?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontSize: 14.0,
+      ),
+      a: TextStyle(
+        color: theme.colorScheme.primary,
+        decoration: TextDecoration.underline,
+      ),
+      code: TextStyle(
+        backgroundColor: theme.colorScheme.surfaceContainer,
+        color: theme.colorScheme.onSurface,
+        fontFamily: 'monospace',
+        fontSize: 16.0,
+      ),
+      codeblockDecoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainer,
+        borderRadius: BorderRadius.circular(8.0),
+        border: Border.all(
+          color: theme.dividerColor.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      listBullet: TextStyle(
+        fontSize: 24.0,
+        color: theme.colorScheme.onSurface,
+      ),
+      blockquote: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+        fontStyle: FontStyle.italic,
+        height: 1.5,
+      ),
+      blockquoteDecoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        border: Border(
+          left: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 4,
+          ),
+        ),
+      ),
+      tableHead: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface,
+        fontWeight: FontWeight.bold,
+        height: 1.5,
+      ),
+      tableBody: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface,
+        height: 1.5,
+      ),
+      tableBorder: TableBorder.all(
+        color: theme.dividerColor.withValues(alpha: 0.3),
+        width: 1,
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      tableHeadAlign: TextAlign.left,
+      tableCellsPadding: const EdgeInsets.all(8.0),
+      tableColumnWidth: const FlexColumnWidth(),
+    );
+  }
+
+  @override
+  TextStyle getEditorStyle(BuildContext context, TextStyle? customStyle) {
+    final theme = Theme.of(context);
+
+    return customStyle ??
+        theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface,
+        ) ??
+        const TextStyle();
+  }
+
+  @override
+  TextStyle getHintStyle(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ) ??
+        const TextStyle();
+  }
+
+  @override
+  MarkdownStyleSheet createHintStyleSheet(BuildContext context) {
+    final theme = Theme.of(context);
+    final baseStyle = createStyleSheet(context);
+
+    return baseStyle.copyWith(
+      p: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        height: 1.5,
+      ),
+    );
+  }
+}

--- a/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+/// Widget for markdown editing mode
+class MarkdownEditorWidget extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final String? hintText;
+  final TextStyle? style;
+  final VoidCallback? onTap;
+
+  const MarkdownEditorWidget({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    this.hintText,
+    this.style,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return TextField(
+      controller: controller,
+      focusNode: focusNode,
+      maxLines: null,
+      expands: true,
+      style: style ??
+          theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface,
+          ),
+      textAlignVertical: TextAlignVertical.top,
+      decoration: InputDecoration(
+        hintText: hintText,
+        hintStyle: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+        border: InputBorder.none,
+        contentPadding: const EdgeInsets.all(16.0),
+        filled: false,
+      ),
+      onTap: () {
+        try {
+          if (focusNode.canRequestFocus && !focusNode.hasFocus) {
+            focusNode.requestFocus();
+          }
+          onTap?.call();
+        } catch (e) {}
+      },
+      onChanged: (value) {
+        try {} catch (e) {}
+      },
+    );
+  }
+}

--- a/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
@@ -41,7 +41,6 @@ class MarkdownEditorWidget extends StatelessWidget {
         filled: false,
       ),
       onTap: onTap,
-      onChanged: (value) {},
     );
   }
 }

--- a/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_editor_widget.dart
@@ -40,17 +40,8 @@ class MarkdownEditorWidget extends StatelessWidget {
         contentPadding: const EdgeInsets.all(16.0),
         filled: false,
       ),
-      onTap: () {
-        try {
-          if (focusNode.canRequestFocus && !focusNode.hasFocus) {
-            focusNode.requestFocus();
-          }
-          onTap?.call();
-        } catch (e) {}
-      },
-      onChanged: (value) {
-        try {} catch (e) {}
-      },
+      onTap: onTap,
+      onChanged: (value) {},
     );
   }
 }

--- a/lib/components/markdown_editor/widgets/markdown_preview_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_preview_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import '../models/markdown_editor_interfaces.dart';
+
+/// Widget for markdown preview mode
+class MarkdownPreviewWidget extends StatelessWidget {
+  final TextEditingController controller;
+  final String? hintText;
+  final bool enableLinkHandling;
+  final void Function(String text, String? href, String title)? onTapLink;
+  final IMarkdownStyleProvider styleProvider;
+
+  const MarkdownPreviewWidget({
+    super.key,
+    required this.controller,
+    this.hintText,
+    this.enableLinkHandling = true,
+    this.onTapLink,
+    required this.styleProvider,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: controller,
+        builder: (context, value, child) {
+          final text = value.text;
+          final displayText = text.isEmpty ? hintText ?? '' : text;
+
+          final styleSheet =
+              text.isEmpty ? styleProvider.createHintStyleSheet(context) : styleProvider.createStyleSheet(context);
+
+          return Markdown(
+            data: displayText,
+            onTapLink: enableLinkHandling ? onTapLink : null,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            styleSheet: styleSheet,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/components/markdown_editor/widgets/markdown_toolbar_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_toolbar_widget.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:markdown_toolbar/markdown_toolbar.dart';
+import '../models/markdown_editor_interfaces.dart';
+import '../config/markdown_editor_translation_keys.dart';
+
+/// Widget for markdown toolbar with configurable styling
+class MarkdownToolbarWidget extends StatelessWidget {
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final Color? backgroundColor;
+  final bool showPreviewToggle;
+  final bool isPreviewMode;
+  final VoidCallback? onPreviewToggle;
+  final IMarkdownToolbarConfiguration toolbarConfiguration;
+  final Map<String, String>? translations;
+
+  const MarkdownToolbarWidget({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    this.backgroundColor,
+    this.showPreviewToggle = true,
+    this.isPreviewMode = false,
+    this.onPreviewToggle,
+    required this.toolbarConfiguration,
+    this.translations,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final toolbarBgColor = backgroundColor ?? theme.cardTheme.color ?? theme.colorScheme.surface;
+    final toolbarStyle = toolbarConfiguration.configureToolbarStyle(theme, toolbarBgColor);
+    final tooltips = toolbarConfiguration.configureTooltipsUsingKeys(translations: translations);
+
+    return Container(
+      decoration: const BoxDecoration(
+        color: Colors.transparent,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Center(
+              child: _buildToolbar(tooltips, toolbarStyle),
+            ),
+          ),
+          if (showPreviewToggle) _buildPreviewToggle(theme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToolbar(Map<String, String> tooltips, MarkdownToolbarStyle style) {
+    final toolbar = MarkdownToolbar(
+      controller: controller,
+      useIncludedTextField: false,
+      focusNode: focusNode,
+      collapsable: style.collapsible,
+      backgroundColor: backgroundColor ?? Colors.transparent,
+      borderRadius: style.borderRadius,
+      iconColor: style.iconColor,
+      iconSize: style.iconSize,
+      dropdownTextColor: style.dropdownTextColor,
+      width: style.width,
+      height: style.height,
+      spacing: style.spacing,
+      runSpacing: style.runSpacing,
+      alignment: style.alignment ?? WrapAlignment.center,
+      showTooltips: true,
+      imageTooltip: tooltips['image'] ?? '',
+      headingTooltip: tooltips['heading'] ?? '',
+      checkboxTooltip: tooltips['checkbox'] ?? '',
+      boldTooltip: tooltips['bold'] ?? '',
+      italicTooltip: tooltips['italic'] ?? '',
+      strikethroughTooltip: tooltips['strikethrough'] ?? '',
+      linkTooltip: tooltips['link'] ?? '',
+      codeTooltip: tooltips['code'] ?? '',
+      bulletedListTooltip: tooltips['bulletedList'] ?? '',
+      numberedListTooltip: tooltips['numberedList'] ?? '',
+      quoteTooltip: tooltips['quote'] ?? '',
+      horizontalRuleTooltip: tooltips['horizontalRule'] ?? '',
+    );
+
+    if (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) {
+      return SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: toolbar,
+      );
+    }
+
+    return toolbar;
+  }
+
+  Widget _buildPreviewToggle(ThemeData theme) {
+    return Container(
+      margin: const EdgeInsets.all(8),
+      child: IconButton(
+        icon: Icon(
+          isPreviewMode ? Icons.edit : Icons.visibility,
+          size: 20,
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+        ),
+        onPressed: onPreviewToggle,
+        tooltip: isPreviewMode
+            ? (translations?[MarkdownEditorTranslationKeys.editTooltip] ?? 'Edit')
+            : (translations?[MarkdownEditorTranslationKeys.previewTooltip] ?? 'Preview'),
+        padding: const EdgeInsets.all(4),
+        constraints: const BoxConstraints(
+          minWidth: 32,
+          minHeight: 32,
+        ),
+        style: IconButton.styleFrom(
+          backgroundColor: Colors.transparent,
+          foregroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+          hoverColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/markdown_editor/widgets/markdown_toolbar_widget.dart
+++ b/lib/components/markdown_editor/widgets/markdown_toolbar_widget.dart
@@ -82,41 +82,56 @@ class MarkdownToolbarWidget extends StatelessWidget {
       horizontalRuleTooltip: tooltips['horizontalRule'] ?? '',
     );
 
+    // Wrap with semantic container for accessibility
+    final semanticToolbar = Semantics(
+      label: 'Markdown formatting toolbar',
+      hint: 'Use toolbar buttons to format text',
+      child: toolbar,
+    );
+
     if (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS) {
       return SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        child: toolbar,
+        child: semanticToolbar,
       );
     }
 
-    return toolbar;
+    return semanticToolbar;
   }
 
   Widget _buildPreviewToggle(ThemeData theme) {
+    final buttonLabel = isPreviewMode ? 'Switch to edit mode' : 'Switch to preview mode';
+    final buttonHint = isPreviewMode ? 'Return to markdown editing mode' : 'View formatted markdown output';
+
     return Container(
       margin: const EdgeInsets.all(8),
-      child: IconButton(
-        icon: Icon(
-          isPreviewMode ? Icons.edit : Icons.visibility,
-          size: 20,
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
-        ),
-        onPressed: onPreviewToggle,
-        tooltip: isPreviewMode
-            ? (translations?[MarkdownEditorTranslationKeys.editTooltip] ?? 'Edit')
-            : (translations?[MarkdownEditorTranslationKeys.previewTooltip] ?? 'Preview'),
-        padding: const EdgeInsets.all(4),
-        constraints: const BoxConstraints(
-          minWidth: 32,
-          minHeight: 32,
-        ),
-        style: IconButton.styleFrom(
-          backgroundColor: Colors.transparent,
-          foregroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.8),
-          hoverColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+      child: Semantics(
+        button: true,
+        label: buttonLabel,
+        hint: buttonHint,
+        child: IconButton(
+          icon: Icon(
+            isPreviewMode ? Icons.edit : Icons.visibility,
+            size: 20,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+          ),
+          onPressed: onPreviewToggle,
+          tooltip: isPreviewMode
+              ? (translations?[MarkdownEditorTranslationKeys.editTooltip] ?? 'Edit')
+              : (translations?[MarkdownEditorTranslationKeys.previewTooltip] ?? 'Preview'),
+          padding: const EdgeInsets.all(4),
+          constraints: const BoxConstraints(
+            minWidth: 32,
+            minHeight: 32,
+          ),
+          style: IconButton.styleFrom(
+            backgroundColor: Colors.transparent,
+            foregroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+            hoverColor: theme.colorScheme.onSurface.withValues(alpha: 0.1),
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
           ),
         ),
       ),

--- a/lib/components/numeric_input/numeric_input.dart
+++ b/lib/components/numeric_input/numeric_input.dart
@@ -20,6 +20,7 @@ class NumericInput extends StatefulWidget {
   final Color? iconColor;
   final Map<NumericInputTranslationKey, String>? translations;
   final NumericInputStyle style;
+  final double? textFieldWidth;
 
   const NumericInput({
     super.key,
@@ -35,6 +36,7 @@ class NumericInput extends StatefulWidget {
     this.iconColor,
     this.translations,
     this.style = NumericInputStyle.minimal,
+    this.textFieldWidth,
   });
 
   @override
@@ -49,6 +51,27 @@ class _NumericInputState extends State<NumericInput> {
     super.initState();
     final startValue = widget.value ?? widget.initialValue;
     _controller = TextEditingController(text: startValue.toString());
+  }
+
+  /// Calculate optimal text field width based on text metrics
+  double _measureTextFieldWidth(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle = theme.textTheme.bodyMedium ?? const TextStyle();
+    final suffix = widget.valueSuffix ?? '';
+
+    // Use a representative maximum-length numeric string (e.g., for 3-4 digit input)
+    const sample = '0000';
+
+    final painter = TextPainter(
+      text: TextSpan(text: '$sample$suffix', style: textStyle),
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    )..layout();
+
+    // Add some horizontal padding so the text doesn't touch edges
+    const horizontalPadding = 16.0;
+
+    return painter.width + horizontalPadding;
   }
 
   @override
@@ -199,7 +222,7 @@ class _NumericInputState extends State<NumericInput> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12.0),
             child: SizedBox(
-              width: 60,
+              width: widget.textFieldWidth ?? _measureTextFieldWidth(context),
               child: TextField(
                 controller: _controller,
                 textAlign: TextAlign.center,

--- a/lib/components/numeric_input/numeric_input.dart
+++ b/lib/components/numeric_input/numeric_input.dart
@@ -196,30 +196,34 @@ class _NumericInputState extends State<NumericInput> {
                 ),
         ),
         if (widget.style == NumericInputStyle.contained)
-          Expanded(
-            child: TextField(
-              controller: _controller,
-              textAlign: TextAlign.center,
-              keyboardType: TextInputType.number,
-              inputFormatters: [
-                FilteringTextInputFormatter.allow(RegExp(r'^[0-9]*$')),
-              ],
-              decoration: InputDecoration(
-                border: InputBorder.none,
-                contentPadding: EdgeInsets.zero,
-                isDense: true,
-                hintText: widget.valueSuffix != null ? '0 ${widget.valueSuffix}' : '0',
-                hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w500,
-                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
-                    ),
-                suffixText: widget.valueSuffix,
-                suffixStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.w500,
-                    ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12.0),
+            child: SizedBox(
+              width: 60,
+              child: TextField(
+                controller: _controller,
+                textAlign: TextAlign.center,
+                keyboardType: TextInputType.number,
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'^[0-9]*$')),
+                ],
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+                  isDense: true,
+                  hintText: widget.valueSuffix != null ? '0 ${widget.valueSuffix}' : '0',
+                  hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
+                  suffixText: widget.valueSuffix,
+                  suffixStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                ),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+                onChanged: _onValueChanged,
               ),
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
-              onChanged: _onValueChanged,
             ),
           )
         else ...[

--- a/lib/utils/responsive_dialog_helper.dart
+++ b/lib/utils/responsive_dialog_helper.dart
@@ -94,11 +94,7 @@ class ResponsiveDialogHelper {
           context: context,
           barrierDismissible: isDismissible,
           builder: (BuildContext context) {
-            return Center(
-              child: SingleChildScrollView(
-                child: effectiveMobileChild,
-              ),
-            );
+            return effectiveMobileChild;
           },
         );
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -235,8 +235,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -376,6 +389,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.3-main.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
+  markdown_toolbar:
+    dependency: "direct main"
+    description:
+      name: markdown_toolbar
+      sha256: "5f4e2548afe96cc2ccdad22da87d380e4726d2d3385ddbb7035aa94daf9a4d47"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   matcher:
     dependency: transitive
     description:
@@ -432,6 +461,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -557,6 +594,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "81777b08c498a292d93ff2feead633174c386291e35612f8da438d6e92c4447e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.20"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.4"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -615,4 +716,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,11 @@ dependencies:
   # UI components and utilities
   modal_bottom_sheet: ^3.0.0
 
+  # Markdown editor dependencies
+  flutter_markdown: ^0.7.6+3
+  markdown_toolbar: ^0.5.0
+  url_launcher: ^6.3.0+3
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 🚀 Motivation and Context

This pull request introduces a comprehensive Markdown editor component to the acore package. The component provides a full-featured Markdown editing experience with live preview, configurable toolbar, link handling, and responsive design.

### 📋 Checklist for Reviewer

- [x] Tests passed locally.
- [x] Commit history is clean and descriptive.
- [x] Documentation updated (if applicable).
- [ ] Code quality standards were met (e.g., linter passed).

## Summary by Sourcery

Introduce a reusable, configurable Markdown editor component with live preview, toolbar, and link handling, and integrate it into the shared components package.

New Features:
- Add a modular Markdown editor widget with simple and fully configurable constructors, supporting preview mode, link handling, and toolbar customization.
- Provide markdown-specific controller, styling provider, toolbar configuration, and link handler abstractions to enable extensibility and localization.
- Expose the Markdown editor through the shared components export and add user-facing documentation for usage, configuration, and translation integration.

Enhancements:
- Adjust the contained numeric input layout to use a fixed-width, padded text field for improved alignment and spacing.
- Simplify responsive dialog behavior on mobile by rendering the provided mobile child directly instead of wrapping it in a centered scroll view.

Build:
- Add flutter_markdown, markdown_toolbar, and url_launcher as dependencies for markdown rendering, toolbar controls, and URL launching support.

Documentation:
- Add comprehensive documentation for the Markdown editor component, including features, API reference, customization, and integration examples.